### PR TITLE
Refactor getItemId and fix matching old catalogue paths to ids in context

### DIFF
--- a/src/bootstrap-tenant/bootstrapper/grids.ts
+++ b/src/bootstrap-tenant/bootstrapper/grids.ts
@@ -29,11 +29,10 @@ async function setItemIds(
       await Promise.all(
         row.columns.map(async (column) => {
           const { itemId } = await getItemId({
+            context,
             externalReference: column.item?.externalReference,
             cataloguePath: column.item?.cataloguePath,
-            context,
             language: context.defaultLanguage.code,
-            tenantId: context.tenantId,
           })
           if (itemId) {
             column.itemId = itemId
@@ -97,7 +96,7 @@ async function publishGrid(
 ) {
   return context.callPIM({
     query: gql`
-      mutation($id: ID!, $language: String!) {
+      mutation ($id: ID!, $language: String!) {
         grid {
           publish(id: $id, language: $language) {
             id

--- a/src/bootstrap-tenant/bootstrapper/items.ts
+++ b/src/bootstrap-tenant/bootstrapper/items.ts
@@ -1480,10 +1480,14 @@ export async function setItems({
               externalReference,
               tree: { path },
             } = response?.data?.[shape?.type]?.update
-            context.itemCataloguePathToIDMap.set(path, id)
+            context.itemCataloguePathToIDMap.set(item.cataloguePath || path, {
+              itemId: id,
+            })
 
             if (externalReference) {
-              context.itemExternalReferenceToIDMap.set(externalReference, id)
+              context.itemExternalReferenceToIDMap.set(externalReference, {
+                itemId: id,
+              })
             }
           }
         })
@@ -1529,9 +1533,13 @@ export async function setItems({
           externalReference,
           tree: { path },
         } = response?.data?.[shape?.type]?.create
-        context.itemCataloguePathToIDMap.set(path, id)
+        context.itemCataloguePathToIDMap.set(item.cataloguePath || path, {
+          itemId: id,
+        })
         if (externalReference) {
-          context.itemExternalReferenceToIDMap.set(externalReference, id)
+          context.itemExternalReferenceToIDMap.set(externalReference, {
+            itemId: id,
+          })
         }
         itemId = id
       }
@@ -1568,12 +1576,11 @@ export async function setItems({
     }
 
     const itemAndParentId = await getItemId({
+      context,
       externalReference: item.externalReference,
       cataloguePath: item.cataloguePath,
-      context,
-      language: context.defaultLanguage.code,
-      tenantId: context.tenantId,
       shapeIdentifier: item.shape,
+      language: context.defaultLanguage.code,
     })
 
     item.id = itemAndParentId.itemId
@@ -1581,11 +1588,11 @@ export async function setItems({
 
     if (item.parentExternalReference || item.parentCataloguePath) {
       const parentItemAndParentId = await getItemId({
+        context,
         externalReference: item.parentExternalReference,
         cataloguePath: item.parentCataloguePath,
-        context,
+        shapeIdentifier: item.shape,
         language: context.defaultLanguage.code,
-        tenantId: context.tenantId,
       })
       parentId = parentItemAndParentId.itemId
     }
@@ -1684,11 +1691,11 @@ export async function setItems({
         itemRelations.map(async (itemRelation) => {
           if (typeof itemRelation === 'object') {
             const { itemId } = await getItemId({
+              context,
               externalReference: itemRelation.externalReference,
               cataloguePath: itemRelation.cataloguePath,
-              context,
+              shapeIdentifier: item.shape,
               language: context.defaultLanguage.code,
-              tenantId: context.tenantId,
             })
 
             if (itemId) {

--- a/src/bootstrap-tenant/bootstrapper/utils/get-item-id.test.ts
+++ b/src/bootstrap-tenant/bootstrapper/utils/get-item-id.test.ts
@@ -1,0 +1,154 @@
+import test from 'ava'
+import { BootstrapperContext } from '.'
+import { IcallAPIResult } from './api'
+import { getItemId, IGetItemIdProps, ItemAndParentId } from './get-item-id'
+
+interface testCase {
+  name: string
+  props: IGetItemIdProps
+  expected: ItemAndParentId
+}
+
+const testCases: testCase[] = [
+  {
+    name: 'gets item id by catalogue path from context if it exists',
+    props: {
+      context: {
+        itemCataloguePathToIDMap: new Map<string, ItemAndParentId>().set(
+          '/foo/bar/baz',
+          { itemId: 'some-id', parentId: 'some-parent-id' }
+        ),
+      } as BootstrapperContext,
+      language: 'en',
+      cataloguePath: '/foo/bar/baz',
+    },
+    expected: {
+      itemId: 'some-id',
+      parentId: 'some-parent-id',
+    },
+  },
+  {
+    name: 'gets item id by catalogue path from the api if it exists',
+    props: {
+      context: {
+        callCatalogue: async (_) =>
+          ({
+            data: {
+              catalogue: {
+                id: 'some-id',
+                parent: {
+                  id: 'some-parent-id',
+                },
+              },
+            },
+          } as IcallAPIResult),
+        itemCataloguePathToIDMap: new Map<string, ItemAndParentId>(),
+      } as BootstrapperContext,
+      language: 'en',
+      cataloguePath: '/foo/bar/baz',
+    },
+    expected: {
+      itemId: 'some-id',
+      parentId: 'some-parent-id',
+    },
+  },
+  {
+    name: 'gets item id by external reference from context if it exists',
+    props: {
+      context: {
+        itemExternalReferenceToIDMap: new Map<string, ItemAndParentId>().set(
+          'some-item',
+          { itemId: 'some-id', parentId: 'some-parent-id' }
+        ),
+      } as BootstrapperContext,
+      language: 'en',
+      externalReference: 'some-item',
+    },
+    expected: {
+      itemId: 'some-id',
+      parentId: 'some-parent-id',
+    },
+  },
+  {
+    name: 'gets item id by external reference from the api if it exists',
+    props: {
+      context: {
+        callPIM: async (_) =>
+          ({
+            data: {
+              item: {
+                getMany: [
+                  {
+                    id: 'some-id',
+                    tree: {
+                      parentId: 'some-parent-id',
+                    },
+                  },
+                ],
+              },
+            },
+          } as IcallAPIResult),
+        itemExternalReferenceToIDMap: new Map<string, ItemAndParentId>(),
+      } as BootstrapperContext,
+      language: 'en',
+      externalReference: 'some-item',
+    },
+    expected: {
+      itemId: 'some-id',
+      parentId: 'some-parent-id',
+    },
+  },
+  {
+    name: 'only gets items by external reference from the api matching the provided shape identifier',
+    props: {
+      context: {
+        callPIM: async (_) =>
+          ({
+            data: {
+              item: {
+                getMany: [
+                  {
+                    id: 'some-wrong-id',
+                    tree: {
+                      parentId: 'some-wrong-parent-id',
+                    },
+                    shape: {
+                      identifier: 'some-wrong-shape',
+                    },
+                  },
+                  {
+                    id: 'some-id',
+                    tree: {
+                      parentId: 'some-parent-id',
+                    },
+                    shape: {
+                      identifier: 'some-shape',
+                    },
+                  },
+                ],
+              },
+            },
+          } as IcallAPIResult),
+        itemExternalReferenceToIDMap: new Map<string, ItemAndParentId>(),
+      } as BootstrapperContext,
+      language: 'en',
+      externalReference: 'some-item',
+      shapeIdentifier: 'some-shape',
+    },
+    expected: {
+      itemId: 'some-id',
+      parentId: 'some-parent-id',
+    },
+  },
+]
+
+testCases.forEach((tc) =>
+  test.serial(tc.name, async (t) => {
+    const actual = await getItemId(tc.props)
+    t.deepEqual(
+      actual,
+      tc.expected,
+      'id and parent respose matches expected value'
+    )
+  })
+)


### PR DESCRIPTION
This PR:
- Stores the _old_ catalogue path with the _new_ item id in context. This allows item relations to correctly reference items where the catalogue path has changed between tenants. If the old catalogue path is not provided in spec, it will use the new one.
- Refactors and tests `getItemById`