### PR TITLE
Add session id alternative to access tokens

### DIFF
--- a/src/bootstrap-tenant/bootstrapper/index.ts
+++ b/src/bootstrap-tenant/bootstrapper/index.ts
@@ -183,6 +183,24 @@ export class Bootstrapper extends EventEmitter {
 
   getStatus = () => this.status
 
+  setSessionId = (sessionId: string) => {
+    // PIM
+    this.PIMAPIManager = createAPICaller({
+      uri: `https://${
+        this.env === 'dev'
+          ? 'pim-dev.crystallize.digital'
+          : 'pim.crystallize.com'
+      }/graphql`,
+      errorNotifier: (error: BootstrapperError) => {
+        this.emit(EVENT_NAMES.ERROR, error)
+      },
+    })
+
+    this.PIMAPIManager.CRYSTALLIZE_SESSION_ID = sessionId
+
+    this.context.callPIM = this.PIMAPIManager.push
+  }
+
   setAccessToken = (ACCESS_TOKEN_ID: string, ACCESS_TOKEN_SECRET: string) => {
     // PIM
     this.PIMAPIManager = createAPICaller({
@@ -273,6 +291,7 @@ export class Bootstrapper extends EventEmitter {
         tenantId: this.context.tenantId,
         accessTokenId: this.PIMAPIManager?.CRYSTALLIZE_ACCESS_TOKEN_ID,
         accessTokenSecret: this.PIMAPIManager?.CRYSTALLIZE_ACCESS_TOKEN_SECRET,
+        sessionId: this.PIMAPIManager?.CRYSTALLIZE_SESSION_ID,
         origin:
           this.env === 'dev' ? '-dev.crystallize.digital' : '.crystallize.com',
       })

--- a/src/bootstrap-tenant/bootstrapper/utils/api.ts
+++ b/src/bootstrap-tenant/bootstrapper/utils/api.ts
@@ -40,6 +40,7 @@ export class ApiManager {
   CRYSTALLIZE_ACCESS_TOKEN_ID = ''
   CRYSTALLIZE_ACCESS_TOKEN_SECRET = ''
   CRYSTALLIZE_STATIC_AUTH_TOKEN = ''
+  CRYSTALLIZE_SESSION_ID = ''
 
   constructor(url: string) {
     this.url = url
@@ -148,12 +149,17 @@ export class ApiManager {
         this.url,
         item.props.query,
         item.props.variables,
-        {
-          'X-Crystallize-Access-Token-Id': this.CRYSTALLIZE_ACCESS_TOKEN_ID,
-          'X-Crystallize-Access-Token-Secret':
-            this.CRYSTALLIZE_ACCESS_TOKEN_SECRET,
-          'X-Crystallize-Static-Auth-Token': this.CRYSTALLIZE_STATIC_AUTH_TOKEN,
-        }
+        this.CRYSTALLIZE_SESSION_ID
+          ? {
+              Cookie: `connect.sid=${this.CRYSTALLIZE_SESSION_ID}`,
+            }
+          : {
+              'X-Crystallize-Access-Token-Id': this.CRYSTALLIZE_ACCESS_TOKEN_ID,
+              'X-Crystallize-Access-Token-Secret':
+                this.CRYSTALLIZE_ACCESS_TOKEN_SECRET,
+              'X-Crystallize-Static-Auth-Token':
+                this.CRYSTALLIZE_STATIC_AUTH_TOKEN,
+            }
       )
       if (this.logLevel === 'verbose') {
         console.log(JSON.stringify(response, null, 1))


### PR DESCRIPTION
Allows for provided a session id as an alternative to access tokens, making import utilities usable by CrystallizeAPI/Apps.