### PR TITLE
feat: add fallback folder and emit error

### DIFF
--- a/src/bootstrap-tenant/bootstrapper/index.ts
+++ b/src/bootstrap-tenant/bootstrapper/index.ts
@@ -146,6 +146,7 @@ export class Bootstrapper extends EventEmitter {
 
     tenantId: '',
     tenantIdentifier: '',
+    fallbackFolderId: '',
 
     /**
      * A map keeping a reference of all of the topics in the current
@@ -239,6 +240,15 @@ export class Bootstrapper extends EventEmitter {
 
   setSpec(spec: JsonSpec) {
     this.SPEC = spec
+  }
+
+  /**
+   * Folder to import items to if the target parent can't be found.
+   *
+   * @param id folder id
+   */
+  setFallbackFolderId(id: string) {
+    this.context.fallbackFolderId = id
   }
 
   setTenantIdentifier = async (tenantIdentifier: string) => {

--- a/src/bootstrap-tenant/bootstrapper/items.ts
+++ b/src/bootstrap-tenant/bootstrapper/items.ts
@@ -1736,7 +1736,7 @@ export async function setItems({
         shapeIdentifier: item.shape,
         language: context.targetLanguage || context.defaultLanguage,
       })
-      parentId = parentItemAndParentId.itemId
+      parentId = parentItemAndParentId.itemId || context.fallbackFolderId
     }
 
     // If the item exists in Crystallize already
@@ -1947,10 +1947,9 @@ export async function setItems({
                           if (itemRelationComponentIndex !== -1) {
                             chunk[
                               itemRelationComponentIndex
-                            ].itemRelations.itemIds =
-                              await getItemIdsForItemRelation(
-                                jsonChunk[itemRelationId] as JSONItemRelation[]
-                              )
+                            ].itemRelations.itemIds = await getItemIdsForItemRelation(
+                              jsonChunk[itemRelationId] as JSONItemRelation[]
+                            )
                           }
                         })
                       )

--- a/src/bootstrap-tenant/bootstrapper/items.ts
+++ b/src/bootstrap-tenant/bootstrapper/items.ts
@@ -1736,7 +1736,17 @@ export async function setItems({
         shapeIdentifier: item.shape,
         language: context.targetLanguage || context.defaultLanguage,
       })
-      parentId = parentItemAndParentId.itemId || context.fallbackFolderId
+      parentId = parentItemAndParentId.itemId
+      if (!parentId) {
+        parentId = context.fallbackFolderId
+        onUpdate({
+          error: {
+            code: 'PARENT_FOLDER_NOT_FOUND',
+            message: `Cannot find the specified parent folder for item`,
+            item,
+          },
+        })
+      }
     }
 
     // If the item exists in Crystallize already

--- a/src/bootstrap-tenant/bootstrapper/utils/index.ts
+++ b/src/bootstrap-tenant/bootstrapper/utils/index.ts
@@ -101,6 +101,7 @@ export interface BootstrapperContext {
   client?: MassClientInterface
   tenantId: string
   tenantIdentifier: string
+  fallbackFolderId: string
   defaultLanguage: string
   targetLanguage?: string
   languages: JSONLanguage[]

--- a/src/bootstrap-tenant/bootstrapper/utils/index.ts
+++ b/src/bootstrap-tenant/bootstrapper/utils/index.ts
@@ -66,6 +66,7 @@ export interface AreaError {
     | 'CANNOT_HANDLE_ITEM'
     | 'CANNOT_HANDLE_PRODUCT'
     | 'CANNOT_HANDLE_ITEM_RELATION'
+    | 'PARENT_FOLDER_NOT_FOUND'
     | 'OTHER'
   item?: JSONItem
 }


### PR DESCRIPTION
A custom fallback folder id allows for defining a custom folder to place items into if their specified parent reference/path does not exist. A `PARENT_FOLDER_NOT_FOUND` error is also emitted.

This is an ID (not a path/reference) to avoid extra queries.

Fixes #45 
