### PR TITLE
Export stock locations instead of single stock value

### DIFF
--- a/src/bootstrap-tenant/bootstrapper/utils/get-all-catalogue-items.ts
+++ b/src/bootstrap-tenant/bootstrapper/utils/get-all-catalogue-items.ts
@@ -13,6 +13,7 @@ import {
   JSONProductSubscriptionPlanPricing,
   JSONProductVariant,
   JSONProductVariantPriceVariants,
+  JSONProductVariantStockLocations,
   JSONProductVariantSubscriptionPlanMeteredVariableTier,
 } from '../../json-spec'
 import {
@@ -235,7 +236,16 @@ export async function getAllCatalogueItems(
             isDefault: v.isDefault,
             attributes,
             externalReference: v.externalReference,
-            stock: v.stock,
+            stock: v.stockLocations?.reduce(
+              (
+                acc: JSONProductVariantStockLocations,
+                { identifier, stock }: { identifier: string; stock: number }
+              ) => {
+                acc[identifier] = stock
+                return acc
+              },
+              {}
+            ),
             images: v.images?.map((i: any, index: number) =>
               handleImage(i, `${v.sku}.images.${index}`)
             ),


### PR DESCRIPTION
Reduces the stock locations array into an object of type `JSONProductVariantStockLocations`. This is then saved in the spec as `stock` instead of just the default stock location value. This is to fix the export not containing other stock location values.