### PR TITLE
fix: encode file url for download

### DIFF
--- a/src/bootstrap-tenant/bootstrapper/utils/remote-file-upload.ts
+++ b/src/bootstrap-tenant/bootstrapper/utils/remote-file-upload.ts
@@ -39,7 +39,7 @@ async function downloadRemoteOrLocal(fileURL: string) {
     await fs.promises.access(fileURL)
     return fs.promises.readFile(fileURL)
   } catch (e) {
-    return download(fileURL)
+    return download(encodeURI(fileURL))
   }
 }
 


### PR DESCRIPTION
Fixes the case where alternative characters are used in filenames, for example Norwegian or Swedish characters, resulting in a 404 for the URL.