### PR TITLE
Feature/spec speed

### DIFF
--- a/.changeset/large-panthers-play.md
+++ b/.changeset/large-panthers-play.md
@@ -1,0 +1,7 @@
+---
+'@crystallize/import-utilities': minor
+---
+
+Certain internals in the items area are now running in parallel for the spec creation. This increases the speed of spec creation of items with roughly 40%.
+
+This also introduces an internal load balancing mechanism, which is designed to keep the request counts below the threshold of Crystallize APIs

--- a/src/bootstrap-tenant/__dev__create-spec.ts
+++ b/src/bootstrap-tenant/__dev__create-spec.ts
@@ -21,29 +21,31 @@ async function createSpec() {
   )
 
   bootstrapper.setTenantIdentifier(tenantIdentifier)
-  bootstrapper.config.multilingual = false
+  bootstrapper.config.multilingual = true
   // bootstrapper.config.logLevel = 'verbose'
 
   bootstrapper.on(EVENT_NAMES.ERROR, (error: BootstrapperError) => {
-    if (!error.willRetry) {
+    if (error.willRetry) {
       console.log(error)
     }
   })
 
+  const timeStart = new Date()
   const spec = await bootstrapper.createSpec({
-    languages: false,
-    vatTypes: false,
-    priceVariants: false,
+    languages: true,
+    vatTypes: true,
+    priceVariants: true,
     shapes: true,
-    topicMaps: false,
-    grids: false,
-    items: false,
-    stockLocations: false,
-    subscriptionPlans: false,
+    topicMaps: true,
+    grids: true,
+    items: true,
+    stockLocations: true,
+    subscriptionPlans: true,
     onUpdate: (areaUpdate) => {
       console.log(JSON.stringify(areaUpdate, null, 1))
     },
   })
+  const timeEnd = new Date()
 
   writeFileSync(
     `./json-spec/${tenantIdentifier}.json`,
@@ -51,7 +53,11 @@ async function createSpec() {
     'utf-8'
   )
 
-  console.log(`✨ Spec created (${tenantIdentifier}.json) ✨`)
+  console.log(
+    `✨ Spec created (${tenantIdentifier}.json). Duration: ${
+      (timeStart.getTime() - timeEnd.getTime()) / 1000
+    }s ✨`
+  )
 }
 
 createSpec()

--- a/src/bootstrap-tenant/bootstrapper/index.ts
+++ b/src/bootstrap-tenant/bootstrapper/index.ts
@@ -271,15 +271,6 @@ export class Bootstrapper extends EventEmitter {
      */
     await sleep(5)
 
-    if (this.PIMAPIManager && this.config.multilingual) {
-      /**
-       * Due to a potential race condition when operating on
-       * multiple languages on the same time, we need to limit
-       * the amount of workers to 1 for now
-       */
-      this.PIMAPIManager.MAX_WORKERS = 1
-    }
-
     const r = await this.context.callPIM({
       query: gql`
           {
@@ -608,6 +599,15 @@ export class Bootstrapper extends EventEmitter {
       await this.ensureTenantExists()
 
       await this.getTenantBasics()
+
+      if (this.PIMAPIManager && this.config.multilingual) {
+        /**
+         * Due to a potential race condition when operating on
+         * multiple languages on the same time, we need to limit
+         * the amount of workers to 1 for now
+         */
+        this.PIMAPIManager.useSingleWorker()
+      }
 
       // Store the config in the context for easy access
       this.context.config = this.config

--- a/src/bootstrap-tenant/bootstrapper/utils/get-all-catalogue-items.ts
+++ b/src/bootstrap-tenant/bootstrapper/utils/get-all-catalogue-items.ts
@@ -277,16 +277,18 @@ export async function getAllCatalogueItems(
 
         const rawChilds = pageResponse.data?.tree?.getNode?.children || []
 
-        for (let i = 0; i < rawChilds.length; i++) {
-          const pathValid = pathShouldBeIncluded(rawChilds[i].path)
+        await Promise.all(
+          rawChilds.map(async (rawChild: any) => {
+            const pathValid = pathShouldBeIncluded(rawChild.path)
 
-          if (pathValid.descendants || pathValid.thisItem) {
-            const item = await getItem(rawChilds[i])
-            if (item) {
-              children.push(item)
+            if (pathValid.descendants || pathValid.thisItem) {
+              const item = await getItem(rawChild)
+              if (item) {
+                children.push(item)
+              }
             }
-          }
-        }
+          })
+        )
 
         return children.sort(byTreePosition)
       }
@@ -464,15 +466,17 @@ export async function getAllCatalogueItems(
       }
     }[] = rootItemsResponse.data?.tree?.getNode?.children || []
 
-    for (let i = 0; i < rootItems.length; i++) {
-      const pathValid = pathShouldBeIncluded(rootItems[i].path)
-      if (pathValid.descendants || pathValid.thisItem) {
-        const item = await getItem(rootItems[i])
-        if (item) {
-          allCatalogueItemsForLanguage.push(item)
+    await Promise.all(
+      rootItems.map(async (rootItem) => {
+        const pathValid = pathShouldBeIncluded(rootItem.path)
+        if (pathValid.descendants || pathValid.thisItem) {
+          const item = await getItem(rootItem)
+          if (item) {
+            allCatalogueItemsForLanguage.push(item)
+          }
         }
-      }
-    }
+      })
+    )
 
     // Filter out on the desired path in the end
     if (options?.basePath?.length) {

--- a/src/bootstrap-tenant/bootstrapper/utils/killable-worker.ts
+++ b/src/bootstrap-tenant/bootstrapper/utils/killable-worker.ts
@@ -1,11 +1,27 @@
 export class KillableWorker {
   isKilled = false
+  isPaused = false
   _workIntervalId: NodeJS.Timeout | null = null
+  _workPausedTimeout: NodeJS.Timeout | null = null
 
   kill() {
     if (this._workIntervalId) {
       clearTimeout(this._workIntervalId)
     }
+    if (this._workPausedTimeout) {
+      clearTimeout(this._workPausedTimeout)
+    }
     this.isKilled = true
+  }
+
+  pauseFor(ms: number, cb: () => void) {
+    if (this._workPausedTimeout) {
+      clearTimeout(this._workPausedTimeout)
+    }
+    this._workPausedTimeout = setTimeout(() => {
+      this.isPaused = false
+      cb()
+    }, ms)
+    this.isPaused = true
   }
 }


### PR DESCRIPTION
Certain internals in the items area are now running in parallel for the spec creation. This increases the speed of spec creation of items with roughly 40%.

This also introduces an internal load balancing mechanism, which is designed to keep the request counts below the threshold of Crystallize APIs. I have also slightly tweaked how the tool behaves if the rate limit of Crystallize is hit, which can happen regardless of its own internal rate limiting.